### PR TITLE
extend http status exception

### DIFF
--- a/src/ox/HttpRequest.java
+++ b/src/ox/HttpRequest.java
@@ -1541,15 +1541,29 @@ public class HttpRequest {
     return this;
   }
 
+  @SuppressWarnings("serial") // Not going to serialize this exception.
+  public class InvalidHttpStatusException extends IllegalStateException {
+    private final int statusCode;
+
+    public InvalidHttpStatusException(String body, int statusCode) {
+      super(body.isEmpty() ? "Error status: " + status() : body);
+      this.statusCode = statusCode;
+    }
+
+    public int getStatusCode() {
+      return statusCode;
+    }
+  }
+
   public HttpRequest checkStatus() {
     if (hasError()) {
       String body = "";
       try {
         body = normalize(getBody());
         Log.debug(body);
-      } catch (Throwable t) {
+      } catch (Exception e) {
       }
-      throw new IllegalStateException(body.isEmpty() ? "Error status: " + status() : body);
+      throw new InvalidHttpStatusException(body, status());
     }
     return this;
   }

--- a/src/ox/HttpRequest.java
+++ b/src/ox/HttpRequest.java
@@ -1546,7 +1546,7 @@ public class HttpRequest {
     private final int statusCode;
 
     public InvalidHttpStatusException(String body, int statusCode) {
-      super(body.isEmpty() ? "Error status: " + status() : body);
+      super(body.isEmpty() ? "Error status: " + statusCode : body);
       this.statusCode = statusCode;
     }
 

--- a/src/ox/HttpRequest.java
+++ b/src/ox/HttpRequest.java
@@ -1562,6 +1562,7 @@ public class HttpRequest {
         body = normalize(getBody());
         Log.debug(body);
       } catch (Exception e) {
+        Log.debug("Failed to retrieve response body for error handling.", e);
       }
       throw new InvalidHttpStatusException(body, status());
     }


### PR DESCRIPTION
This is to extend IllegalStatusException to add a HTTP status code. We can check on the detailed status code for more specific handling.